### PR TITLE
better merit behavior for the eco badge

### DIFF
--- a/app/models/merit/badge_rules.rb
+++ b/app/models/merit/badge_rules.rb
@@ -21,15 +21,15 @@ module Merit
     include Merit::BadgeRulesMethods
 
     def initialize
-      grant_on ['products#create','products#update','products#delete'],  badge: 'thrifter101', temporary: true, to: :user do |product|
+      grant_on ['products#create','products#update','products#destroy'],  badge: 'thrifter101', temporary: true, to: :user do |product|
         product.user.second_hand_percentage < 0.5
       end
 
-      grant_on ['products#create','products#update','products#delete'],  badge: 'thrifter102', temporary: true, to: :user do |product|
+      grant_on ['products#create','products#update','products#destroy'],  badge: 'thrifter102', temporary: true, to: :user do |product|
         product.user.second_hand_percentage >= 0.5 && product.user.second_hand_percentage < 0.8
       end
 
-      grant_on ['products#create','products#update','products#delete'],  badge: 'thrifter103', temporary: true, to: :user do |product|
+      grant_on ['products#create','products#update','products#destroy'],  badge: 'thrifter103', temporary: true, to: :user do |product|
         product.user.second_hand_percentage >= 0.8
       end
 
@@ -37,12 +37,24 @@ module Merit
         proportion.product.user.organic_recycled_materials < 0.3
       end
 
+       grant_on ['products#create','products#update','products#destroy'],  badge: 'eco101', temporary: true, to: :user do |product|
+        product.user.organic_recycled_materials < 0.3
+      end
+
       grant_on ['proportions#create','proportions#destroy'],  badge: 'eco102', temporary: true, to: :owner do |proportion|
         proportion.product.user.organic_recycled_materials >= 0.3 && proportion.product.user.organic_recycled_materials < 0.5
       end
 
+      grant_on ['products#create','products#update','products#destroy'],  badge: 'eco102', temporary: true, to: :user do |product|
+        product.user.organic_recycled_materials >= 0.3 && product.user.organic_recycled_materials < 0.5
+      end
+
       grant_on ['proportions#create','proportions#destroy'],  badge: 'eco103', temporary: true, to: :owner do |proportion|
         proportion.product.user.organic_recycled_materials >= 0.5
+      end
+
+      grant_on ['products#create','products#update','products#destroy'],  badge: 'eco103', temporary: true, to: :user do |product|
+        product.user.organic_recycled_materials >= 0.5
       end
 
       grant_on ['products#update'],  badge: 'recycler101', temporary: true, to: :user do |product|


### PR DESCRIPTION
the eco badge reacted for proportions updates etc but not for product. Meaning the badge did not change even when the product was removed.
Works fine now.