### PR TITLE
Stat purchase

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,18 +8,25 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   def products_lifetime
+    discarded_statuses = ["sold", "recycled", "donated", "thrown away"]
+    discarded_clothes = []
     lifetime = 0
     average_lifetime = 0
-    if products.count > 0
-      products.each do |product|
-        if product.discard_date != nil && product.purchase_date != nil
-        lifetime += (product.discard_date - product.purchase_date)
-        elsif product.discard_date != nil && product.purchase_date == nil
-        lifetime += (product.discard_date - product.created_at)
+      if products.count > 0
+        products.each do |product|
+          if discarded_statuses.include?(product.status)
+            discarded_clothes << product
+          end
         end
+        discarded_clothes.each do |discarded|
+          if discarded.purchase_date != nil
+            lifetime += (discarded.discard_date - discarded.purchase_date)
+          else
+            lifetime += (discarded.discard_date - discarded.created_at.to_date)
+          end
+        end
+        average_lifetime = ((lifetime / discarded_clothes.count) / 365 )* 12
       end
-      average_lifetime = ((lifetime / products.count) / 365 )* 12
-    end
     average_lifetime
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,10 @@ class User < ApplicationRecord
     average_lifetime = 0
     if products.count > 0
       products.each do |product|
-        if product.discard_date != nil
-        lifetime += product.discard_date - product.purchase_date
+        if product.discard_date != nil && product.purchase_date != nil
+        lifetime += (product.discard_date - product.purchase_date)
+        elsif product.discard_date != nil && product.purchase_date == nil
+        lifetime += (product.discard_date - product.created_at)
         end
       end
       average_lifetime = ((lifetime / products.count) / 365 )* 12


### PR DESCRIPTION
The products_lifetime method works better because it only takes discarded clothes in consideration. 
Also the purchase_date is replaced by created_at if purchase_date is null.

At this point I will have to replace the chart chosen to display this because it is not accurate (sorting by category does not make sense with a global lifetime).

I may be choosing a merit badge for this one